### PR TITLE
information for api on android

### DIFF
--- a/mobile/lib/api.js
+++ b/mobile/lib/api.js
@@ -6,3 +6,4 @@ export function fetchDevices(query) {
     res.json()
   );
 }
+//Localhost doesn't work on android, change localhost to ip that the expo client is running on


### PR DESCRIPTION
Added top tab navigation on the Home Screen
Setup the user and device list as components of the Top navigation
Setup api for devices and searching devices
Format user time
Update device status when switch is toggled

Note: Localhost doesn't work on android, update localhost with the IP address of the expo client when its running.